### PR TITLE
doc: Update documentation and code comments to make it clearer what is being done now

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,38 +165,57 @@ This command:
 
 #### Viewing Plugin Logs
 
-To see plugin output and debug messages:
+Plugin logs are stored in the plugin's own directory with automatic rotation (10 files max, 10 MiB each).
 
-**Method 1: Stream Deck Log File**
+**Log Location:**
 
 ```bash
-# macOS - View live logs
-tail -f ~/Library/Logs/com.elgato.StreamDeck/StreamDeck0.log
+~/Library/Application Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin/logs/
 ```
 
-**Method 2: Stream Deck App**
+**View the latest log:**
 
-1. Open Stream Deck application
-2. Go to Preferences → Advanced
-3. Click "Open Plugin Log Folder"
-4. Open the latest log file
+```bash
+cat ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin/logs/org.deverman.ejectalldisks.0.log
+```
 
-**Method 3: Console.app**
+**Follow logs in real-time:**
 
-1. Open Console.app (Applications → Utilities)
-2. Search for "StreamDeck" or "Eject All Disks"
-3. View real-time logs
+```bash
+tail -f ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin/logs/org.deverman.ejectalldisks.0.log
+```
+
+**View recent entries:**
+
+```bash
+tail -200 ~/Library/Application\ Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin/logs/org.deverman.ejectalldisks.0.log
+```
+
+Log files are numbered 0-9, with 0 being the most recent. A new log file is created when the plugin starts or when the current file exceeds 10 MiB.
 
 #### What to Look For in Logs
 
 The plugin outputs these key messages:
 
 ```
-Eject All Disks plugin initializing
-Disk count changed to: 2
+# Startup
+Eject All Disks plugin starting...
+Found Swift binary at: /path/to/eject-disks
+
+# Disk monitoring
+Disk count updated to: 2 for action xxx (forced: false)
+
+# Ejection process
 Ejecting disks...
-Disks ejected: [output]
-Error counting disks: [error details]
+Swift eject completed: 2/2 ejected, 0 failed, took 5.23s
+  [OK] DiskName ejected in 5.20s
+SHOWING SUCCESS ICON - All disks ejected successfully
+
+# Errors
+  [FAIL] DiskName: Unmount of disk16 failed...
+Failed to eject "DiskName": error message
+  Blocking processes: AppName (PID: 1234, User: username)
+SHOWING ERROR ICON - Error ejecting disks: ...
 ```
 
 #### Testing the Disk Count Feature

--- a/src/actions/eject-all-disks.ts
+++ b/src/actions/eject-all-disks.ts
@@ -528,10 +528,22 @@ export class EjectAllDisks extends SingletonAction {
 						timeout: 30000, // 30 second timeout for ejection
 					});
 
+					// Log the raw output for debugging
+					streamDeck.logger.info(`Swift eject raw output: ${stdout}`);
+
 					ejectResult = JSON.parse(stdout) as EjectOutput;
 					streamDeck.logger.info(
-						`Swift eject completed: ${ejectResult.successCount}/${ejectResult.totalCount} in ${ejectResult.totalDuration.toFixed(2)}s`,
+						`Swift eject completed: ${ejectResult.successCount}/${ejectResult.totalCount} ejected, ${ejectResult.failedCount} failed, took ${ejectResult.totalDuration.toFixed(2)}s`,
 					);
+
+					// Log each individual result
+					for (const result of ejectResult.results) {
+						if (result.success) {
+							streamDeck.logger.info(`  [OK] ${result.volume} ejected in ${result.duration.toFixed(2)}s`);
+						} else {
+							streamDeck.logger.error(`  [FAIL] ${result.volume}: ${result.error}`);
+						}
+					}
 
 					// Check for failures and log detailed info
 					if (ejectResult.failedCount > 0) {
@@ -550,6 +562,9 @@ export class EjectAllDisks extends SingletonAction {
 
 						const failures = failedResults.map((r) => `${r.volume}: ${r.error}`).join(", ");
 						ejectError = failures;
+						streamDeck.logger.info(`Setting ejectError: ${ejectError}`);
+					} else {
+						streamDeck.logger.info(`All ${ejectResult.successCount} volumes ejected successfully - no error`);
 					}
 				} catch (error) {
 					streamDeck.logger.warn(`Swift binary eject failed, falling back to shell: ${error}`);
@@ -613,8 +628,9 @@ export class EjectAllDisks extends SingletonAction {
 			}
 
 			// Handle results
+			streamDeck.logger.info(`Decision point: ejectError=${ejectError ? 'SET' : 'null'}, ejectResult=${ejectResult ? 'SET' : 'null'}`);
 			if (ejectError) {
-				streamDeck.logger.error(`Error ejecting disks: ${ejectError}`);
+				streamDeck.logger.error(`SHOWING ERROR ICON - Error ejecting disks: ${ejectError}`);
 
 				// Show error icon
 				await ev.action.setImage(`data:image/svg+xml,${encodeURIComponent(this.createErrorSvg())}`, {
@@ -649,7 +665,7 @@ export class EjectAllDisks extends SingletonAction {
 				}, 2000);
 				this.timeouts.add(timeout);
 			} else {
-				streamDeck.logger.info(`All disks ejected successfully`);
+				streamDeck.logger.info(`SHOWING SUCCESS ICON - All disks ejected successfully`);
 
 				// Show success icon
 				await ev.action.setImage(`data:image/svg+xml,${encodeURIComponent(this.createSuccessSvg())}`, {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances Swift CLI with verbose ejection and a diagnose command, updates the plugin to surface blocking processes and richer logs, and refreshes README with logging, structure, and ejection details.
> 
> - **Swift CLI (`swift/Sources/EjectDisks.swift`)**:
>   - Switch to `diskutil eject` with Swift concurrency; bump version to `2.1.0` and update abstracts.
>   - Add process discovery via `lsof` (`parseLsofOutput`, `getBlockingProcesses`).
>   - Extend JSON schema: `EjectResult.blockingProcesses` and include in parallel ejection results.
>   - Add `--verbose` flag to `eject` to return blocking processes on failures.
>   - Introduce `diagnose` subcommand to list volumes and their blocking processes.
> - **Plugin (TypeScript `src/actions/eject-all-disks.ts`)**:
>   - Use Swift binary `eject --verbose`; parse and log per-volume results and blocking processes.
>   - Improve success/error handling and UI feedback; add detailed decision/log messages.
>   - Add `ProcessInfo` interface and propagate blocking process data.
> - **Docs (`README.md`)**:
>   - Update project structure (Swift sources, logs directory) and logging guidance with paths/commands.
>   - Revise ejection section to document Swift binary primary method, fallback shell, and diagnostic commands (`list`, `diagnose`, `eject --verbose`).
>   - Expand troubleshooting with guidance on blocking apps and Finder behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d28b1a7597e50195bd7f5f629eb561ee879b5ce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->