### PR TITLE
Fix GitHub Actions release upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,11 +72,8 @@ jobs:
 
       - name: Upload to release
         if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/org.deverman.ejectalldisks.streamDeckPlugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/org.deverman.ejectalldisks.streamDeckPlugin
-          asset_name: org.deverman.ejectalldisks.streamDeckPlugin
-          asset_content_type: application/zip


### PR DESCRIPTION
Replace deprecated actions/upload-release-asset@v1 with modern softprops/action-gh-release@v2 This fixes the 'Resource not accessible by integration' error