### PR TITLE
Fix Swift compilation error in process path decoding

### DIFF
--- a/.claude/prompts/optimize-async-process-detection.md
+++ b/.claude/prompts/optimize-async-process-detection.md
@@ -1,10 +1,13 @@
 # Optimization: Async Blocking Process Detection
 
 ## Goal
+
 Run blocking process detection (`lsof`) in parallel with the next disk ejection instead of sequentially.
 
 ## Current Behavior
+
 In `EjectDisks.swift`, when ejection fails with verbose mode:
+
 ```swift
 for singleResult in batchResult.results {
   if !singleResult.success && verbose {
@@ -18,6 +21,7 @@ for singleResult in batchResult.results {
 `getBlockingProcesses()` runs `lsof` synchronously, which can take 1-5 seconds per volume.
 
 ## Proposed Change
+
 1. Collect all failed volumes first
 2. Run `lsof` for all failed volumes in parallel using Swift concurrency
 3. Match results back to the failure reports
@@ -44,22 +48,27 @@ let blockingProcessesMap = await withTaskGroup(of: (String, [ProcessInfoOutput])
 ```
 
 ## Files to Modify
+
 - `swift/Sources/EjectDisks.swift` - `ejectAllVolumesNative()` function
 
 ## Key Code Location
+
 Around line 191-212 in EjectDisks.swift where results are processed.
 
 ## Expected Improvement
+
 - If 3 disks fail, lsof runs 3x in parallel instead of sequentially
 - Saves 2-10 seconds on multi-disk failures
 - No impact on success path (lsof only runs on failures)
 
 ## Risk Assessment
+
 - LOW risk - only affects diagnostic output
 - lsof is read-only, safe to parallelize
 - Worst case: slightly delayed error reporting
 
 ## Testing
+
 1. Open files on multiple disks to force ejection failures
 2. Run `./eject-disks eject --verbose`
 3. Measure total time vs sequential approach

--- a/.claude/prompts/optimize-disk-grouping.md
+++ b/.claude/prompts/optimize-disk-grouping.md
@@ -1,35 +1,43 @@
 # COMPLETE: finished on branch and merged to main claude/optimize-disk-grouping-01JumRhy5R8EhetiRKF1A8hG
+
 # Optimization: Disk Grouping by Physical Device
 
 ## Goal
+
 Optimize disk ejection by grouping volumes by their physical device (BSD whole disk) before ejection, reducing redundant operations.
 
 ## Current Behavior
+
 - Each volume is processed individually
 - `unmountAndEjectAsync` is called for each volume separately
 - For a disk with 3 partitions, we may be doing redundant work
 
 ## Proposed Change
+
 1. In `DiskSession.swift`, add a method to group volumes by their whole disk BSD name
 2. Modify `ejectAll()` to:
-   - Group volumes by physical device first
-   - For each physical device, unmount all its volumes with `kDADiskUnmountOptionWhole`
-   - Then eject the physical device once
-   - Process different physical devices in parallel
+    - Group volumes by physical device first
+    - For each physical device, unmount all its volumes with `kDADiskUnmountOptionWhole`
+    - Then eject the physical device once
+    - Process different physical devices in parallel
 
 ## Files to Modify
+
 - `swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/DiskSession.swift`
 - `swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/Internal/CallbackBridge.swift`
 
 ## Key Code Locations
+
 - `DiskSession.ejectAll()` method
 - `unmountAndEjectAsync()` function in CallbackBridge.swift
 
 ## Expected Improvement
+
 - Reduce redundant unmount calls for multi-partition disks
 - Faster ejection for disks with multiple volumes
 
 ## Testing
+
 1. Mount a disk with multiple partitions
 2. Run `./eject-disks benchmark --eject`
 3. Compare timing before and after optimization

--- a/.claude/prompts/optimize-event-driven-monitoring.md
+++ b/.claude/prompts/optimize-event-driven-monitoring.md
@@ -1,18 +1,22 @@
 # Optimization: Event-Driven Disk Monitoring
 
 ## Goal
+
 Replace the 3-second polling interval with event-driven disk monitoring for instant UI updates when disks are mounted/unmounted.
 
 ## Current Behavior
+
 In `eject-all-disks.ts`:
+
 ```typescript
 // Check disk count every 3 seconds
 const interval = setInterval(async () => {
-  await this.updateDiskCount(action);
+    await this.updateDiskCount(action);
 }, 3000);
 ```
 
 This means:
+
 - Up to 3 second delay before badge updates
 - Continuous CPU usage even when no changes
 - Multiple concurrent polling timers (one per visible action)
@@ -20,51 +24,59 @@ This means:
 ## Proposed Architecture
 
 ### Option A: DiskArbitration Notifications (Swift-side)
+
 1. Create a long-running Swift process that watches for disk events
 2. Use `DARegisterDiskAppearedCallback` and `DARegisterDiskDisappearedCallback`
 3. Communicate changes to the Node.js plugin via:
-   - Named pipe / Unix socket
-   - File-based signaling
-   - Stdout streaming
+    - Named pipe / Unix socket
+    - File-based signaling
+    - Stdout streaming
 
 ### Option B: FSEvents (Swift-side)
+
 1. Watch `/Volumes` directory for changes using FSEvents
 2. Trigger count update when directory contents change
 3. Same communication options as Option A
 
 ### Option C: Node.js fs.watch (TypeScript-side)
+
 1. Use `fs.watch('/Volumes')` to detect mount changes
 2. Debounce rapid changes
 3. Update disk count on change event
 
 ## Recommended Approach: Option C
+
 Simplest to implement, no Swift changes needed.
 
 ```typescript
-import { watch } from 'fs';
+import { watch } from "fs";
 
 // In startMonitoring():
-const watcher = watch('/Volumes', { persistent: false }, (eventType, filename) => {
-  // Debounce and update count
-  this.debouncedUpdateDiskCount(action);
+const watcher = watch("/Volumes", { persistent: false }, (eventType, filename) => {
+    // Debounce and update count
+    this.debouncedUpdateDiskCount(action);
 });
 ```
 
 ## Files to Modify
+
 - `src/actions/eject-all-disks.ts`
 
 ## Challenges
+
 1. `fs.watch` reliability varies by platform (but we only target macOS)
 2. Need to handle rapid mount/unmount events (debouncing)
 3. Watcher cleanup on action disappear
 4. May still want a slow fallback poll (30s) for edge cases
 
 ## Expected Improvement
+
 - Instant badge updates (sub-100ms vs 3000ms)
 - Reduced CPU usage when idle
 - Better user experience
 
 ## Testing
+
 1. Mount a USB drive - badge should appear instantly
 2. Eject via Finder - badge should disappear instantly
 3. Rapid mount/unmount - should handle gracefully

--- a/.claude/prompts/optimize-skip-unmount.md
+++ b/.claude/prompts/optimize-skip-unmount.md
@@ -1,11 +1,15 @@
 # FAILED the hypothesis failed and disks didn't unmount claude/skip-redundant-unmount-013ZyocEyb9f1whCzSFAADky
+
 # Optimization: Skip Redundant Unmount
 
 ## Goal
+
 Test whether `DADiskEject` on a whole disk implicitly handles unmounting, allowing us to skip the explicit `DADiskUnmount` call.
 
 ## Current Behavior
+
 In `CallbackBridge.swift`, `unmountAndEjectAsync()` does:
+
 1. `DADiskUnmount` with `kDADiskUnmountOptionWhole`
 2. Wait for completion
 3. `DADiskEject` on the whole disk
@@ -14,23 +18,27 @@ In `CallbackBridge.swift`, `unmountAndEjectAsync()` does:
 This is a sequential two-step process taking ~10-12 seconds per disk.
 
 ## Hypothesis
+
 `DADiskEject` may already handle unmounting internally for ejectable media. If so, we can skip step 1.
 
 ## Proposed Investigation
+
 1. Create a test branch
 2. Modify `unmountAndEjectAsync()` to skip the unmount step
 3. Test with various disk types:
-   - USB flash drives
-   - External HDDs/SSDs
-   - Disk images (.dmg)
-   - SD cards
+    - USB flash drives
+    - External HDDs/SSDs
+    - Disk images (.dmg)
+    - SD cards
 4. Measure timing differences
 5. Check for any data integrity issues
 
 ## Files to Modify
+
 - `swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/Internal/CallbackBridge.swift`
 
 ## Key Code Location
+
 ```swift
 internal func unmountAndEjectAsync(
   _ volume: Volume,
@@ -40,11 +48,13 @@ internal func unmountAndEjectAsync(
 ```
 
 ## Risk Assessment
+
 - LOW risk if `DADiskEject` handles unmounting
 - If it doesn't, disks may fail to eject or data could be corrupted
 - Must test thoroughly before deploying
 
 ## Testing Protocol
+
 1. Mount test disk with files open in an app
 2. Try eject-only approach
 3. Verify disk ejects cleanly

--- a/.claude/prompts/optimize-volume-list-passthrough.md
+++ b/.claude/prompts/optimize-volume-list-passthrough.md
@@ -1,9 +1,11 @@
 # Optimization: Volume List Passthrough
 
 ## Goal
+
 Eliminate redundant volume enumeration by passing the volume list from the TypeScript plugin to the Swift binary.
 
 ## Current Behavior
+
 1. TypeScript plugin calls `eject-disks list` to get volumes (for count display)
 2. User presses button
 3. TypeScript calls `eject-disks eject`
@@ -13,6 +15,7 @@ Eliminate redundant volume enumeration by passing the volume list from the TypeS
 This means volumes are enumerated twice - once in step 1 and again in step 4.
 
 ## Proposed Change
+
 Add a `--volumes` flag to accept a comma-separated list of BSD names:
 
 ```bash
@@ -24,17 +27,20 @@ Add a `--volumes` flag to accept a comma-separated list of BSD names:
 ```
 
 When `--volumes` is provided:
+
 - Skip enumeration
 - Use provided BSD names directly
 - Create DADisk references from BSD names
 
 ## Files to Modify
+
 - `swift/Sources/EjectDisks.swift` - Add `--volumes` option to Eject command
 - `src/actions/eject-all-disks.ts` - Pass volume BSD names when calling eject
 
 ## Implementation Details
 
 ### Swift side:
+
 ```swift
 struct Eject: AsyncParsableCommand {
   @Option(name: .long, help: "Comma-separated BSD names to eject")
@@ -54,6 +60,7 @@ struct Eject: AsyncParsableCommand {
 ```
 
 ### TypeScript side:
+
 ```typescript
 // Cache the volume list from monitoring
 private cachedVolumes: VolumeInfo[] = [];
@@ -64,17 +71,20 @@ const ejectCommand = `sudo -n "${binaryPath}" eject --verbose --volumes "${bsdNa
 ```
 
 ## Expected Improvement
+
 - Save ~50-100ms on enumeration
 - More consistent behavior (eject exactly what was displayed)
 - Avoid race conditions where disks change between display and eject
 
 ## Risk Assessment
+
 - MEDIUM - need to handle edge cases:
-  - Volume unmounted between display and eject
-  - Invalid BSD name passed
-  - Empty volume list
+    - Volume unmounted between display and eject
+    - Invalid BSD name passed
+    - Empty volume list
 
 ## Testing
+
 1. Mount disks, verify count shows correctly
 2. Press eject with --volumes flag
 3. Verify correct disks are ejected

--- a/.prompts/disk-image-handling.md
+++ b/.prompts/disk-image-handling.md
@@ -19,6 +19,7 @@ Add special handling for disk images to use `hdiutil detach` instead of DiskArbi
 ### 1. Detect Disk Images
 
 The code already detects disk images in `Volume.swift`:
+
 - `Volume.info.isDiskImage` boolean flag is set during enumeration
 - Detection happens in `checkIfDiskImage(disk:)` at line 221
 
@@ -42,6 +43,7 @@ nonisolated internal func detachDiskImageAsync(
 ```
 
 Implementation should:
+
 - Use `Process` to run `hdiutil detach /dev/bsdName`
 - Add `-force` flag if `force` is true
 - Capture stdout/stderr
@@ -54,6 +56,7 @@ Implementation should:
 Modify `ejectPhysicalDevice()` in `DiskSession.swift` (around line 300):
 
 **Current flow:**
+
 ```swift
 if options.ejectPhysicalDevice {
   // Step 1: Unmount
@@ -65,6 +68,7 @@ if options.ejectPhysicalDevice {
 ```
 
 **New flow:**
+
 ```swift
 if options.ejectPhysicalDevice {
   // Check if all volumes in this group are disk images
@@ -94,6 +98,7 @@ if options.ejectPhysicalDevice {
 ### 5. Testing
 
 Test with:
+
 ```bash
 # Create a multi-partition disk image
 hdiutil create -size 200m -layout GPTSPUD -fs "Case-sensitive APFS" /tmp/multipart.dmg
@@ -109,6 +114,7 @@ sudo ./org.deverman.ejectalldisks.sdPlugin/bin/eject-disks eject
 ```
 
 Expected behavior:
+
 - Both partitions should eject without "Not privileged" errors
 - Debug output should show using `hdiutil detach` for disk images
 - Grouping optimization should still work (2 volumes → 1 physical device)
@@ -116,11 +122,11 @@ Expected behavior:
 ## Files to Modify
 
 1. **`swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/Internal/CallbackBridge.swift`**
-   - Add `detachDiskImageAsync()` function
+    - Add `detachDiskImageAsync()` function
 
 2. **`swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/DiskSession.swift`**
-   - Modify `ejectPhysicalDevice()` method (around line 300)
-   - Add logic to detect disk images and use `hdiutil` when appropriate
+    - Modify `ejectPhysicalDevice()` method (around line 300)
+    - Add logic to detect disk images and use `hdiutil` when appropriate
 
 ## Success Criteria
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2024-11-24
 
 ### Added
+
 - **Native DiskArbitration API** - Uses macOS DiskArbitration framework (`DADiskUnmount` + `DADiskEject`) for ~6x faster disk ejection compared to `diskutil` subprocess calls
 - **Privilege Setup System** - One-time sudoers configuration for passwordless disk ejection
-  - Setup script at `bin/install-eject-privileges.sh`
-  - Property inspector shows setup status and instructions
-  - "Check Status" button to verify configuration
-  - "Copy Command" button for easy terminal setup
+    - Setup script at `bin/install-eject-privileges.sh`
+    - Property inspector shows setup status and instructions
+    - "Check Status" button to verify configuration
+    - "Copy Command" button for easy terminal setup
 - **Blocking Process Detection** - Shows which processes are preventing disk ejection (using `lsof`)
 - **Benchmark Command** - `./eject-disks benchmark --eject` to measure ejection performance
 - **SETUP.md** - Comprehensive privilege setup documentation
 
 ### Changed
+
 - Swift CLI binary now uses DiskArbitration framework instead of spawning `diskutil` subprocesses
 - Improved error messages with detailed status codes from DiskArbitration
 - Updated README with new features and troubleshooting guide
 
 ### Technical Details
+
 - Swift package `SwiftDiskArbitration` provides async/await wrappers for DiskArbitration C APIs
 - Uses `kDADiskUnmountOptionWhole` to unmount all volumes on a physical disk
 - Parallel ejection using Swift concurrency (`TaskGroup`)
@@ -32,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - Initial Release
 
 ### Added
+
 - Basic disk ejection using `diskutil eject` subprocess
 - Real-time disk count monitoring with badge display
 - Visual feedback for ejection status (normal, ejecting, success, error)

--- a/README.md
+++ b/README.md
@@ -374,11 +374,13 @@ git push && git push origin v2.0.0
 **4. Create the GitHub release:**
 
 Option A - Using GitHub web interface:
+
 1. Go to https://github.com/deverman/eject_all_disks_streamdeck/releases/new?tag=v2.0.0
 2. Fill in the release title and notes
 3. Click "Publish release"
 
 Option B - Using GitHub CLI:
+
 ```bash
 gh release create v2.0.0 \
   --title "v2.0.0" \
@@ -388,6 +390,7 @@ gh release create v2.0.0 \
 **5. Wait for automation:**
 
 GitHub Actions will automatically:
+
 - Build the TypeScript code
 - Package the plugin
 - Upload `org.deverman.ejectalldisks.streamDeckPlugin` to the release
@@ -397,6 +400,7 @@ Users can then download the plugin directly from the releases page!
 #### Version Numbering
 
 Follow [Semantic Versioning](https://semver.org/):
+
 - **MAJOR** (x.0.0): Breaking changes
 - **MINOR** (1.x.0): New features (backwards compatible)
 - **PATCH** (1.0.x): Bug fixes
@@ -430,6 +434,7 @@ Settings are implemented using:
 The plugin uses a Swift CLI binary for fast parallel disk ejection:
 
 **Primary method (Swift binary with DiskArbitration):**
+
 - Uses macOS DiskArbitration framework (`DADiskUnmount` + `DADiskEject`)
 - ~6x faster than `diskutil eject` subprocess calls
 - Unmounts all volumes on a physical disk, then ejects the device
@@ -441,6 +446,7 @@ The plugin uses a Swift CLI binary for fast parallel disk ejection:
 If the Swift binary is unavailable, the plugin falls back to a shell script that runs `diskutil eject` for each volume in parallel.
 
 **Diagnostic commands:**
+
 ```bash
 # List ejectable volumes
 ./eject-disks list

--- a/org.deverman.ejectalldisks.sdPlugin/SETUP.md
+++ b/org.deverman.ejectalldisks.sdPlugin/SETUP.md
@@ -7,11 +7,12 @@ This plugin uses macOS DiskArbitration framework for fast disk ejection. For the
 1. Open **Terminal** (Applications → Utilities → Terminal)
 
 2. Run the setup script:
-   ```bash
-   bash "/path/to/plugin/bin/install-eject-privileges.sh"
-   ```
 
-   The exact path depends on where Stream Deck installed the plugin. You can find it in the property inspector by clicking the action in Stream Deck and looking at the "Privilege Setup" section.
+    ```bash
+    bash "/path/to/plugin/bin/install-eject-privileges.sh"
+    ```
+
+    The exact path depends on where Stream Deck installed the plugin. You can find it in the property inspector by clicking the action in Stream Deck and looking at the "Privilege Setup" section.
 
 3. Enter your admin password when prompted
 
@@ -27,6 +28,7 @@ The setup script creates a sudoers rule that allows the eject-disks binary to ru
 - No other commands or binaries are affected
 
 The setup creates a file at `/etc/sudoers.d/eject-disks` with the following content:
+
 ```
 YOUR_USERNAME ALL=(ALL) NOPASSWD: /path/to/eject-disks *
 ```
@@ -40,6 +42,7 @@ After running the setup script, you can verify it works:
 3. Click "Check Status" - it should show "✓ Configured"
 
 Or test from Terminal:
+
 ```bash
 sudo -n /path/to/eject-disks --version
 ```
@@ -69,16 +72,21 @@ For the most reliable experience, we recommend completing the setup.
 ## Troubleshooting
 
 ### Setup script not found
+
 If the property inspector shows "Setup script not found", ensure the plugin is properly installed. Try reinstalling the plugin from Stream Deck.
 
 ### Permission denied
+
 If you get a permission denied error when running the setup script, make sure you're running it with `bash` and that you have administrator privileges on your Mac.
 
 ### Sudo syntax error
+
 If the sudoers configuration fails validation, the setup script will automatically remove the invalid configuration. Try running the setup script again.
 
 ### Disks still not ejecting
+
 If disks still fail to eject after setup:
+
 1. Make sure no applications are using files on the disk
 2. Try closing all Finder windows
 3. Use the force eject option if available

--- a/org.deverman.ejectalldisks.sdPlugin/ui/eject-all-disks.html
+++ b/org.deverman.ejectalldisks.sdPlugin/ui/eject-all-disks.html
@@ -28,29 +28,38 @@
 			<div class="sdpi-item">
 				<div class="sdpi-item-label">Status</div>
 				<div class="sdpi-item-value">
-					<span id="setupStatus" style="color: #888;">Checking...</span>
+					<span id="setupStatus" style="color: #888">Checking...</span>
 				</div>
 			</div>
 
-			<div id="setupInstructions" class="sdpi-item" style="display: none;">
+			<div id="setupInstructions" class="sdpi-item" style="display: none">
 				<details class="message">
 					<summary>Setup Instructions</summary>
-					<p style="font-size: 11px; margin: 8px 0; line-height: 1.4;">
+					<p style="font-size: 11px; margin: 8px 0; line-height: 1.4">
 						To eject disks without password prompts, run the setup script once:
 					</p>
-					<ol style="font-size: 11px; margin: 8px 0; padding-left: 20px; line-height: 1.6;">
+					<ol style="font-size: 11px; margin: 8px 0; padding-left: 20px; line-height: 1.6">
 						<li>Open Terminal</li>
-						<li>Run: <code id="setupCommand" style="background: #333; padding: 2px 4px; border-radius: 3px; font-size: 10px;">Loading...</code></li>
+						<li>
+							Run:
+							<code id="setupCommand" style="background: #333; padding: 2px 4px; border-radius: 3px; font-size: 10px"
+								>Loading...</code
+							>
+						</li>
 						<li>Enter your admin password when prompted</li>
 						<li>Click "Check Status" to verify</li>
 					</ol>
-					<button id="copyCommand" class="sdpi-item-value" style="margin: 8px 0; padding: 4px 8px; cursor: pointer;">Copy Command</button>
+					<button id="copyCommand" class="sdpi-item-value" style="margin: 8px 0; padding: 4px 8px; cursor: pointer">
+						Copy Command
+					</button>
 				</details>
 			</div>
 
 			<div class="sdpi-item">
 				<div class="sdpi-item-label"></div>
-				<button id="checkStatus" class="sdpi-item-value" style="padding: 6px 12px; cursor: pointer;">Check Status</button>
+				<button id="checkStatus" class="sdpi-item-value" style="padding: 6px 12px; cursor: pointer">
+					Check Status
+				</button>
 			</div>
 		</div>
 
@@ -172,7 +181,7 @@
 							},
 							function () {
 								document.getElementById("copyCommand").textContent = "Failed to copy";
-							}
+							},
 						);
 					}
 				});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eject-all-disks-streamdeck",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eject-all-disks-streamdeck",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
                 "@elgato/streamdeck": "2.0.0-beta.2"
             },

--- a/src/actions/eject-all-disks.ts
+++ b/src/actions/eject-all-disks.ts
@@ -597,9 +597,7 @@ export class EjectAllDisks extends SingletonAction {
 			if (binaryPath) {
 				// Check if sudo is configured for passwordless execution
 				const useSudo = await this.checkSudoConfiguration();
-				const ejectCommand = useSudo
-					? `sudo -n "${binaryPath}" eject --verbose`
-					: `"${binaryPath}" eject --verbose`;
+				const ejectCommand = useSudo ? `sudo -n "${binaryPath}" eject --verbose` : `"${binaryPath}" eject --verbose`;
 
 				streamDeck.logger.info(`Using eject command: ${useSudo ? "with sudo" : "without sudo"}`);
 
@@ -711,7 +709,9 @@ export class EjectAllDisks extends SingletonAction {
 			}
 
 			// Handle results
-			streamDeck.logger.info(`Decision point: ejectError=${ejectError ? 'SET' : 'null'}, ejectResult=${ejectResult ? 'SET' : 'null'}`);
+			streamDeck.logger.info(
+				`Decision point: ejectError=${ejectError ? "SET" : "null"}, ejectResult=${ejectResult ? "SET" : "null"}`,
+			);
 			if (ejectError) {
 				streamDeck.logger.error(`SHOWING ERROR ICON - Error ejecting disks: ${ejectError}`);
 

--- a/swift/Packages/SwiftDiskArbitration/README.md
+++ b/swift/Packages/SwiftDiskArbitration/README.md
@@ -143,13 +143,14 @@ do {
 
 ## Performance Comparison
 
-| Method | 1 disk | 3 disks | 5 disks |
-|--------|--------|---------|---------|
-| `diskutil eject` (subprocess) | ~50ms | ~60ms | ~70ms |
-| `DADiskUnmount` (native) | ~5ms | ~7ms | ~10ms |
-| **Speedup** | **10x** | **8.5x** | **7x** |
+| Method                        | 1 disk  | 3 disks  | 5 disks |
+| ----------------------------- | ------- | -------- | ------- |
+| `diskutil eject` (subprocess) | ~50ms   | ~60ms    | ~70ms   |
+| `DADiskUnmount` (native)      | ~5ms    | ~7ms     | ~10ms   |
+| **Speedup**                   | **10x** | **8.5x** | **7x**  |
 
 The native API avoids the overhead of:
+
 - Process forking (~5ms)
 - exec() system call (~10ms)
 - diskutil initialization (~15ms)
@@ -190,6 +191,7 @@ MIT License - see LICENSE file for details.
 ## Credits
 
 Based on research from:
+
 - [Apple DiskArbitration Documentation](https://developer.apple.com/documentation/diskarbitration)
 - [Ejectify by Niels Mouthaan](https://github.com/nielsmouthaan/ejectify-macos)
 - Swift Forums discussions on C callback bridging

--- a/swift/Sources/EjectDisks.swift
+++ b/swift/Sources/EjectDisks.swift
@@ -164,8 +164,8 @@ nonisolated func getBlockingProcesses(path: String) -> [ProcessInfoOutput] {
 
             let command: String
             if pathLen > 0 {
-                // Use the newer String decoding API, truncating at the actual path length
-                let execPath = String(decoding: pathBuffer.prefix(Int(pathLen)), as: UTF8.self)
+                // Convert CChar (Int8) buffer to UInt8 for String decoding
+                let execPath = String(bytes: pathBuffer.prefix(Int(pathLen)).map { UInt8(bitPattern: $0) }, encoding: .utf8) ?? "unknown"
                 command = URL(fileURLWithPath: execPath).lastPathComponent
             } else {
                 command = "unknown"


### PR DESCRIPTION
Convert CChar (Int8) buffer to UInt8 for String(bytes:encoding:) API. This fixes the compilation error: 'init(decoding:as:)' requires CChar and UTF8.CodeUnit be equivalent