### PR TITLE
Add write permissions for release asset upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-and-package:
     runs-on: macos-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add 'contents: write' permission to workflow to fix 'Resource not accessible by integration' error. GitHub Actions requires explicit permissions to upload assets to releases.