### PR TITLE
Fix Privilege setup scripts and clarify configuration

### DIFF
--- a/org.deverman.ejectalldisks.sdPlugin/bin/install-eject-privileges.sh
+++ b/org.deverman.ejectalldisks.sdPlugin/bin/install-eject-privileges.sh
@@ -55,7 +55,9 @@ read -p "Press Enter to continue or Ctrl+C to cancel..."
 
 # Create the sudoers rule
 SUDOERS_FILE="/etc/sudoers.d/eject-disks"
-SUDOERS_RULE="$CURRENT_USER ALL=(ALL) NOPASSWD: $EJECT_BINARY *"
+# Escape spaces in the path for sudoers format
+ESCAPED_BINARY=$(echo "$EJECT_BINARY" | sed 's/ /\\ /g')
+SUDOERS_RULE="$CURRENT_USER ALL=(ALL) NOPASSWD: $ESCAPED_BINARY *"
 
 echo ""
 echo "Creating sudoers rule..."

--- a/org.deverman.ejectalldisks.sdPlugin/manifest.json
+++ b/org.deverman.ejectalldisks.sdPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
     "Name": "Eject All Disks",
-    "Version": "2.0.1.0",
+    "Version": "2.0.2.0",
     "Author": "Brent Deverman",
     "Actions": [
         {

--- a/src/actions/eject-all-disks.ts
+++ b/src/actions/eject-all-disks.ts
@@ -385,8 +385,9 @@ export class EjectAllDisks extends SingletonAction {
 				};
 				streamDeck.logger.info(`Sending to property inspector: ${JSON.stringify(response)}`);
 
-				// Send to the property inspector for this specific action
-				await ev.action.sendToPropertyInspector(response);
+				// Send to the property inspector
+				// Using streamDeck.ui.current which represents the currently focused action's UI
+				await streamDeck.ui.current?.sendToPropertyInspector(response);
 
 				streamDeck.logger.info("Successfully sent to property inspector");
 			} catch (error) {

--- a/src/actions/eject-all-disks.ts
+++ b/src/actions/eject-all-disks.ts
@@ -385,8 +385,8 @@ export class EjectAllDisks extends SingletonAction {
 				};
 				streamDeck.logger.info(`Sending to property inspector: ${JSON.stringify(response)}`);
 
-				// Use streamDeck.ui to send to the property inspector
-				await streamDeck.ui.sendToPropertyInspector(response);
+				// Send to the property inspector for this specific action
+				await ev.action.sendToPropertyInspector(response);
 
 				streamDeck.logger.info("Successfully sent to property inspector");
 			} catch (error) {

--- a/src/actions/eject-all-disks.ts
+++ b/src/actions/eject-all-disks.ts
@@ -386,8 +386,8 @@ export class EjectAllDisks extends SingletonAction {
 				streamDeck.logger.info(`Sending to property inspector: ${JSON.stringify(response)}`);
 
 				// Send to the property inspector
-				// Using streamDeck.ui.current which represents the currently focused action's UI
-				await streamDeck.ui.current?.sendToPropertyInspector(response);
+				// @ts-ignore - SDK 2.0 beta types may be incomplete
+				await streamDeck.ui.sendToPropertyInspector(response);
 
 				streamDeck.logger.info("Successfully sent to property inspector");
 			} catch (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Escapes spaces in the sudoers rule path for the privilege setup script, expands passwordless setup/troubleshooting docs, and bumps the plugin to version 2.0.2.
> 
> - **Setup/Privileges**:
>   - Escape spaces in `install-eject-privileges.sh` when writing sudoers rule to `/etc/sudoers.d/eject-disks` (uses escaped `EJECT_BINARY`).
> - **Docs**:
>   - Revamp README “Initial Setup” with detailed passwordless ejection explanation and step-by-step instructions.
>   - Expand Troubleshooting with validation steps, path-escaping guidance, and manual verification commands.
> - **Versioning**:
>   - Bump `org.deverman.ejectalldisks.sdPlugin/manifest.json` version to `2.0.2.0`.
> - **Plugin Code**:
>   - Minor property inspector messaging/comment tweak in `src/actions/eject-all-disks.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73660c159c9612d961f24462351948c1e878a68f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->