### PR TITLE
fix: Ensure that tests are working with new metadata

### DIFF
--- a/swift-plugin/Tests/EjectAllDisksPluginTests/PluginMetadataTests.swift
+++ b/swift-plugin/Tests/EjectAllDisksPluginTests/PluginMetadataTests.swift
@@ -17,7 +17,7 @@ struct PluginMetadataTests {
 
     @Test("Plugin has correct name")
     func pluginName() {
-        #expect(EjectAllDisksPlugin.name == "Eject All Disks")
+        #expect(EjectAllDisksPlugin.name == "SafeEject: One-Push Disk Manager")
     }
 
     @Test("Plugin has description")
@@ -71,7 +71,7 @@ struct EjectActionMetadataTests {
 
     @Test("Action has correct name")
     func actionName() {
-        #expect(EjectAction.name == "Eject All Disks")
+        #expect(EjectAction.name == "SafeEject All")
     }
 
     @Test("Action has correct UUID")


### PR DESCRIPTION
Fix tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates test expectations to align with renamed plugin/action metadata.
> 
> - Changes `PluginMetadataTests.swift` to expect plugin name `"SafeEject: One-Push Disk Manager"` and action name `"SafeEject All"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f515f605f829f94b0dace969b657c6a1fe435d87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->