### PR TITLE
Add diagnostic logging for eject flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,20 +70,6 @@ jobs:
           # Ensure the installed plugin uses the optimized release binary (swift run defaults to debug without -c).
           INSTALL_DIR="$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin"
           cp ".build/release/org.deverman.ejectalldisks" "$INSTALL_DIR/org.deverman.ejectalldisks"
-
-          # StreamDeckPlugin's generated manifest omits the top-level UUID; streamdeck pack requires it.
-          python3 - <<'PY'
-          import json, os
-          plugin_uuid = "org.deverman.ejectalldisks"
-          install_dir = os.path.expanduser("~/Library/Application Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin")
-          manifest_path = os.path.join(install_dir, "manifest.json")
-          with open(manifest_path, "r", encoding="utf-8") as f:
-              data = json.load(f)
-          data["UUID"] = plugin_uuid
-          with open(manifest_path, "w", encoding="utf-8") as f:
-              json.dump(data, f, indent=4, ensure_ascii=False)
-              f.write("\n")
-          PY
           echo "✅ Plugin exported"
 
       - name: Copy assets to export
@@ -129,8 +115,7 @@ jobs:
       - name: Validate plugin
         run: |
           PLUGIN_DIR="$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins/org.deverman.ejectalldisks.sdPlugin"
-          streamdeck validate "$PLUGIN_DIR" || true
-        continue-on-error: true
+          streamdeck validate --no-update-check "$PLUGIN_DIR"
 
       - name: Package plugin
         run: |

--- a/swift-plugin/Package.resolved
+++ b/swift-plugin/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/deverman/StreamDeckPlugin.git",
       "state" : {
         "branch" : "main",
-        "revision" : "7eb2a8fe2016316ac53aac41ddbe47bac7f1420d"
+        "revision" : "4ab9413d360a8a8657172914c4f98ba3f86743f3"
       }
     },
     {

--- a/swift-plugin/Sources/EjectAllDisksPlugin/Actions/EjectAction.swift
+++ b/swift-plugin/Sources/EjectAllDisksPlugin/Actions/EjectAction.swift
@@ -61,6 +61,34 @@ import OSLog
 fileprivate let log = Logger(subsystem: "org.deverman.ejectalldisks", category: "action")
 fileprivate let debugLoggingEnabled = ProcessInfo.processInfo.environment["EJECT_ALL_DISKS_DEBUG"] == "1"
 
+/// Process-local eject state shared across action instances.
+///
+/// This intentionally is not persisted in Stream Deck global settings. Persisting
+/// transient state can leave the plugin stuck after Stream Deck quits or macOS
+/// reboots during an eject operation.
+private final class EjectOperationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inProgress = false
+
+    func begin() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !inProgress else {
+            return false
+        }
+
+        inProgress = true
+        return true
+    }
+
+    func finish() {
+        lock.lock()
+        inProgress = false
+        lock.unlock()
+    }
+}
+
 /// Settings for the Eject action
 struct EjectActionSettings: Codable, Hashable, Sendable {
     var showTitle: Bool = true
@@ -108,8 +136,8 @@ class EjectAction: KeyAction {
     var context: String
     var coordinates: StreamDeck.Coordinates?
 
-    /// Access to global ejecting state
-    @GlobalSetting(\.isEjecting) var isEjecting: Bool
+    /// Shared in-memory state that prevents simultaneous eject operations.
+    private static let ejectOperationState = EjectOperationState()
 
     /// Timer for polling disk count
     private var pollingTimer: DispatchSourceTimer?
@@ -139,6 +167,7 @@ class EjectAction: KeyAction {
     // MARK: - Lifecycle Events
 
     func willAppear(device: String, payload: AppearEvent<Settings>) {
+        log.info("Action appeared")
         if debugLoggingEnabled {
             log.debug("Action appeared: context=\(self.context), device=\(device), isInMultiAction=\(payload.isInMultiAction)")
         }
@@ -178,6 +207,7 @@ class EjectAction: KeyAction {
     }
 
     func willDisappear(device: String, payload: AppearEvent<Settings>) {
+        log.info("Action disappeared")
         if debugLoggingEnabled {
             log.debug("Action disappeared from device \(device)")
         }
@@ -259,14 +289,19 @@ class EjectAction: KeyAction {
     // MARK: - Key Events
 
     func keyUp(device: String, payload: KeyEvent<Settings>, longPress: Bool) {
-        if longPress { return }
+        log.info("Key up received: longPress=\(longPress, privacy: .public)")
+
+        if longPress {
+            log.info("Ignoring long press key release")
+            return
+        }
 
         if debugLoggingEnabled {
             log.debug("Key up - starting eject operation")
         }
 
         // Prevent multiple simultaneous eject operations
-        guard !isEjecting else {
+        guard Self.ejectOperationState.begin() else {
             log.warning("Eject already in progress, ignoring key press")
             return
         }
@@ -284,7 +319,12 @@ class EjectAction: KeyAction {
     /// Performs the disk eject operation
     @MainActor
     private func performEject(showTitle: Bool) async {
-        isEjecting = true
+        defer {
+            Self.ejectOperationState.finish()
+            log.info("Eject operation state cleared")
+        }
+
+        log.info("Eject operation started")
 
         // Show ejecting state
         setImage(toImage: "ejecting", withExtension: "svg", subdirectory: "imgs/actions/eject")
@@ -293,11 +333,10 @@ class EjectAction: KeyAction {
         do {
             let session = try DiskSession()
             let volumes = await session.enumerateEjectableVolumes()
+            log.info("Enumerated ejectable volumes: count=\(volumes.count, privacy: .public)")
 
             if volumes.isEmpty {
-                if debugLoggingEnabled {
-                    log.debug("No disks to eject")
-                }
+                log.info("No disks to eject")
                 setTitle(to: showTitle ? "No Disks" : nil, target: nil, state: nil)
                 showOk()
             } else {
@@ -330,10 +369,9 @@ class EjectAction: KeyAction {
         // Reset display after delay
         try? await Task.sleep(for: .seconds(2))
 
-        isEjecting = false
-
         // Refresh disk count immediately before updating display
         self.diskCount = await DiskSession.shared.ejectableVolumeCount()
+        log.info("Post-eject disk count refreshed: count=\(self.diskCount, privacy: .public)")
         setImage(toImage: "icon", withExtension: "svg", subdirectory: "imgs/actions/eject")
 
         updateDisplay(showTitle: showTitle)
@@ -368,12 +406,60 @@ class EjectAction: KeyAction {
     /// PRIVACY: We don't log volume names as they may contain sensitive information.
     /// Volume names like "ConfidentialProject" or "ClientBackup" could reveal user data.
     private func logResults(_ result: BatchEjectResult) {
-        if debugLoggingEnabled {
-            log.debug("Eject completed: \(result.successCount)/\(result.totalCount) succeeded")
-        }
+        log.info(
+            "Eject completed: success=\(result.successCount, privacy: .public), failed=\(result.failedCount, privacy: .public), total=\(result.totalCount, privacy: .public), duration=\(result.totalDuration, privacy: .public)s"
+        )
+
         if result.failedCount > 0 {
-            log.warning("\(result.failedCount) volume(s) failed to eject")
+            log.warning("\(result.failedCount, privacy: .public) volume(s) failed to eject")
         }
+
+        for singleResult in result.results where !singleResult.success {
+            let bsdName = singleResult.bsdName ?? "unknown"
+            let category = diagnosticCategory(for: singleResult.errorMessage)
+            log.warning(
+                "Eject failure: bsd=\(bsdName, privacy: .public), category=\(category, privacy: .public), duration=\(singleResult.duration, privacy: .public)s"
+            )
+            if debugLoggingEnabled, let errorMessage = singleResult.errorMessage {
+                log.debug("Eject failure detail: bsd=\(bsdName, privacy: .public), message=\(errorMessage, privacy: .private)")
+            }
+        }
+    }
+
+    /// Converts detailed system errors into a sanitized diagnostic category.
+    private func diagnosticCategory(for message: String?) -> String {
+        guard let message else {
+            return "unknown"
+        }
+
+        let normalized = message.lowercased()
+
+        if normalized.contains("permission") || normalized.contains("permitted") {
+            return "permission"
+        }
+        if normalized.contains("privilege") {
+            return "privilege"
+        }
+        if normalized.contains("busy") || normalized.contains("exclusive") || normalized.contains("in use") {
+            return "busy"
+        }
+        if normalized.contains("timeout") || normalized.contains("timed out") {
+            return "timeout"
+        }
+        if normalized.contains("not mounted") {
+            return "not_mounted"
+        }
+        if normalized.contains("not found") {
+            return "not_found"
+        }
+        if normalized.contains("not ready") {
+            return "not_ready"
+        }
+        if normalized.contains("unsupported") {
+            return "unsupported"
+        }
+
+        return "other"
     }
 
     /// Formats a user-friendly error title based on the eject result

--- a/swift-plugin/Sources/EjectAllDisksPlugin/EjectAllDisksPlugin.swift
+++ b/swift-plugin/Sources/EjectAllDisksPlugin/EjectAllDisksPlugin.swift
@@ -15,12 +15,6 @@ import OSLog
 fileprivate let log = Logger(subsystem: "org.deverman.ejectalldisks", category: "plugin")
 fileprivate let debugLoggingEnabled = ProcessInfo.processInfo.environment["EJECT_ALL_DISKS_DEBUG"] == "1"
 
-/// Global settings shared across all actions
-extension GlobalSettings {
-    /// Whether an eject operation is currently in progress
-    @Entry var isEjecting: Bool = false
-}
-
 /// Main plugin class for Eject All Disks
 @main
 class EjectAllDisksPlugin: Plugin {
@@ -33,7 +27,7 @@ class EjectAllDisksPlugin: Plugin {
     static var categoryIcon: String? = "imgs/plugin/category-icon"
     static var author: String = "Brent Deverman"
     static var icon: String = "imgs/plugin/marketplace"
-    static var version: String = "3.0.2"
+    static var version: String = "3.0.3.0"
     static var uuid: String = "org.deverman.ejectalldisks"
 
     static var os: [PluginOS] = [.macOS("13")]
@@ -54,6 +48,7 @@ class EjectAllDisksPlugin: Plugin {
     // MARK: - Initialization
 
     required init() {
+        log.info("EjectAllDisksPlugin initialized")
         if debugLoggingEnabled {
             log.debug("EjectAllDisksPlugin initialized")
         }

--- a/swift-plugin/Tests/EjectAllDisksPluginTests/PluginMetadataTests.swift
+++ b/swift-plugin/Tests/EjectAllDisksPluginTests/PluginMetadataTests.swift
@@ -36,9 +36,9 @@ struct PluginMetadataTests {
         let version = EjectAllDisksPlugin.version
         #expect(!version.isEmpty)
 
-        // Should be in semver-like format (x.y.z)
         let components = version.split(separator: ".")
-        #expect(components.count >= 2, "Version should have at least major.minor")
+        #expect(components.count == 4, "Stream Deck CLI expects major.minor.patch.build")
+        #expect(components.allSatisfy { Int($0) != nil }, "Version components should be numeric")
     }
 
     @Test("Plugin has icon path")

--- a/swift-plugin/build.sh
+++ b/swift-plugin/build.sh
@@ -19,6 +19,34 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+validate_plugin_bundle() {
+    local install_dir="$1"
+    local validate_output
+    local validate_status
+
+    set +e
+    validate_output="$(streamdeck validate --no-update-check "$install_dir" 2>&1)"
+    validate_status=$?
+    set -e
+
+    printf '%s\n' "$validate_output"
+
+    if printf '%s\n' "$validate_output" | grep -Eq '^[[:space:]]*[0-9]+:[0-9]+[[:space:]]+error[[:space:]]'; then
+        echo -e "${RED}Plugin validation failed with errors.${NC}" >&2
+        exit 1
+    fi
+
+    if [ "$validate_status" -ne 0 ]; then
+        if printf '%s\n' "$validate_output" | grep -Eq '0 errors?, [1-9][0-9]* warnings?'; then
+            echo -e "${YELLOW}Plugin validation completed with warnings only.${NC}"
+            return 0
+        fi
+
+        echo -e "${RED}streamdeck validate failed unexpectedly.${NC}" >&2
+        exit "$validate_status"
+    fi
+}
+
 echo -e "${GREEN}Building EjectAllDisksPlugin...${NC}"
 
 # Change to the swift-plugin directory
@@ -59,8 +87,8 @@ if [ "$1" == "--install" ]; then
 
     if command -v streamdeck >/dev/null 2>&1; then
         echo ""
-        echo -e "${YELLOW}Validating plugin bundle (non-fatal)...${NC}"
-        streamdeck validate "$INSTALL_DIR" || true
+        echo -e "${YELLOW}Validating plugin bundle...${NC}"
+        validate_plugin_bundle "$INSTALL_DIR"
     fi
 else
     echo ""

--- a/swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/DiskSession.swift
+++ b/swift/Packages/SwiftDiskArbitration/Sources/SwiftDiskArbitration/DiskSession.swift
@@ -81,6 +81,9 @@ public struct SingleEjectResult: Sendable, Codable {
   /// Path to the volume
   public let volumePath: String
 
+  /// BSD device name, safe to include in diagnostic logs (e.g., disk2s1)
+  public let bsdName: String?
+
   /// Whether the ejection succeeded
   public let success: Bool
 
@@ -333,6 +336,7 @@ public actor DiskSession {
         SingleEjectResult(
           volumeName: volume.info.name,
           volumePath: volume.info.path,
+          bsdName: volume.info.bsdName,
           success: false,
           errorMessage: "Session is invalid",
           duration: 0
@@ -422,6 +426,7 @@ public actor DiskSession {
           SingleEjectResult(
             volumeName: volume.info.name,
             volumePath: volume.info.path,
+            bsdName: volume.info.bsdName,
             success: false,
             errorMessage: unmountResult.error?.description ?? "Unmount failed",
             duration: unmountResult.duration
@@ -438,6 +443,7 @@ public actor DiskSession {
         SingleEjectResult(
           volumeName: volume.info.name,
           volumePath: volume.info.path,
+          bsdName: volume.info.bsdName,
           success: ejectResult.success,
           errorMessage: ejectResult.error?.description,
           duration: totalDuration
@@ -453,6 +459,7 @@ public actor DiskSession {
           SingleEjectResult(
             volumeName: volume.info.name,
             volumePath: volume.info.path,
+            bsdName: volume.info.bsdName,
             success: result.success,
             errorMessage: result.error?.description,
             duration: result.duration

--- a/swift/Packages/SwiftDiskArbitration/Tests/SwiftDiskArbitrationTests/DiskSessionTests.swift
+++ b/swift/Packages/SwiftDiskArbitration/Tests/SwiftDiskArbitrationTests/DiskSessionTests.swift
@@ -119,6 +119,7 @@ struct BatchEjectResultTests {
     let result = SingleEjectResult(
       volumeName: "USB Drive",
       volumePath: "/Volumes/USB Drive",
+      bsdName: "disk2s1",
       success: true,
       errorMessage: nil,
       duration: 0.05
@@ -132,6 +133,7 @@ struct BatchEjectResultTests {
 
     #expect(decoded.volumeName == result.volumeName)
     #expect(decoded.volumePath == result.volumePath)
+    #expect(decoded.bsdName == result.bsdName)
     #expect(decoded.success == result.success)
     #expect(decoded.errorMessage == result.errorMessage)
     #expect(decoded.duration == result.duration)
@@ -142,6 +144,7 @@ struct BatchEjectResultTests {
     let result = SingleEjectResult(
       volumeName: "Busy Drive",
       volumePath: "/Volumes/Busy Drive",
+      bsdName: "disk3s1",
       success: false,
       errorMessage: "Spotlight is indexing",
       duration: 0.01


### PR DESCRIPTION
## Summary
- add always-on sanitized OSLog diagnostics for key presses, eject lifecycle, result counts, and failure categories
- replace persisted isEjecting global setting with a process-local synchronized eject operation state
- update to the StreamDeckPlugin fork that emits the root manifest UUID and bump plugin version to 3.0.3.0
- harden local and release validation so errors fail while warning-only validation can pass

## Validation
- swift-plugin: swift test
- SwiftDiskArbitration: swift test
- swift-plugin: ./build.sh --install
- streamdeck validate --no-update-check installed plugin: passed with category warning only
- local Stream Deck eject run produced sanitized logs for key up, eject start, volume count, success summary, post-eject count, and state clear